### PR TITLE
Change defaultGetAuth

### DIFF
--- a/graphql-client/src/index.js
+++ b/graphql-client/src/index.js
@@ -174,5 +174,5 @@ function defaultGetAuth (tokenName) {
   // get the authentication token from local storage if it exists
   const token = localStorage.getItem(tokenName)
   // return the headers to the context so httpLink can read them
-  return token
+  return token ? `Bearer ${token}` : ''
 }


### PR DESCRIPTION
I think this was removed in some refactoring?

The current `defaultGetAuth` will send `authorization: 'null'` header if there is no token in localStorage. That makes `express-jwt` fail with something like `Format is Authorization: Bearer [token]` even when setting `credentialsRequired: false`.

Thanks so much for all the updates! I can now use this plugin since it has `apollo-link-state` already :)