### PR TITLE
Add labels to form fields, use form tag

### DIFF
--- a/generator/templates/vue-apollo/examples/src/components/ApolloExample.vue
+++ b/generator/templates/vue-apollo/examples/src/components/ApolloExample.vue
@@ -5,7 +5,7 @@
       <label for="field-name" class="label">Name</label>
       <input
         v-model="name"
-        placeholder="Type a name"         
+        placeholder="Type a name"
         class="input"
         id="field-name"
       >

--- a/generator/templates/vue-apollo/examples/src/components/ApolloExample.vue
+++ b/generator/templates/vue-apollo/examples/src/components/ApolloExample.vue
@@ -2,10 +2,12 @@
   <div class="apollo-example">
     <!-- Cute tiny form -->
     <div class="form">
+      <label for="field-name" class="label">Name</label>
       <input
         v-model="name"
-        placeholder="Type a name"
+        placeholder="Type a name"         
         class="input"
+        id="field-name"
       >
     </div>
 
@@ -62,12 +64,15 @@
       @done="newMessage = ''"
     >
       <template slot-scope="{ mutate }">
-        <input
-          v-model="newMessage"
-          placeholder="Type a message"
-          class="input"
-          @keyup.enter="formValid && mutate()"
-        >
+        <form v-on:submit.prevent="formValid && mutate()">
+          <label for="field-message">Message</label>
+          <input
+            id="field-message"
+            v-model="newMessage"
+            placeholder="Type a message"
+            class="input"
+          >
+        </form>
       </template>
     </ApolloMutation>
 
@@ -82,7 +87,9 @@
     </div>
 
     <div class="image-input">
+      <label for="field-image">Image</label>
       <input
+        id="field-image"
         type="file"
         accept="image/*"
         required
@@ -148,6 +155,11 @@ export default {
 .apollo,
 .message {
   padding: 12px;
+}
+
+label {
+  display: block;
+  margin-bottom: 6px;
 }
 
 .input {


### PR DESCRIPTION
According to [WCAG 2, 2.4.6](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1&showtechniques=324%2C331%2C246#headings-and-labels), form fields should have labels associated with them. This PR adds labels to the example form fields.

It also wraps the message field in a form, so that it can be submitted by pressing `ENTER` per browser defaults, rather than through adding our own keyboard handler.