### PR TITLE
Update manual code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,6 @@ Then in the root instance, set the `provide` option:
 new Vue({
   el: '#app',
   // Add this line
-  provide: createProvider().provide(),
+  apolloProvider: createProvider(),
 })
 ```


### PR DESCRIPTION
Change manual code section to reflect updated way of adding provider. Fixes this warning in browser from old method `<ApolloProvider>.provide() is deprecated. Use the 'apolloProvider' option instead with the provider object directly.`