### PR TITLE
fix: issue with already defined "CacheControlScope"

### DIFF
--- a/generator/templates/api-server/default/apollo-server/schema.graphql
+++ b/generator/templates/api-server/default/apollo-server/schema.graphql
@@ -7,9 +7,9 @@ scalar Upload
 # Cache control
 directive @cacheControl(
   maxAge: Int,
-  scope: CacheControlScope
+  scope: CacheControlScopeEnum
 ) on OBJECT | FIELD_DEFINITION
-enum CacheControlScope {
+enum CacheControlScopeEnum {
   PUBLIC
   PRIVATE
 }

--- a/generator/templates/api-server/default/apollo-server/schema.graphql
+++ b/generator/templates/api-server/default/apollo-server/schema.graphql
@@ -2,18 +2,6 @@
 scalar JSON
 scalar Upload
 
-# Included directives
-
-# Cache control
-directive @cacheControl(
-  maxAge: Int,
-  scope: CacheControlScopeEnum
-) on OBJECT | FIELD_DEFINITION
-enum CacheControlScopeEnum {
-  PUBLIC
-  PRIVATE
-}
-
 <% if (addExamples) { _%>
 # It will increment!
 type Counter {


### PR DESCRIPTION
Seems that this variable is defined somewhere, set a new name for this enum in order to fix it.
Fix the #54  issue.

Maybe is related to this variable declaration on  apollo server? https://github.com/apollographql/apollo-server/blob/88417b73980b0199aae0ad7b3f0c043d7fabfda7/packages/apollo-server-core/src/ApolloServer.ts#L166