### PR TITLE
Add host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ If your project is meant to be used as a package installed from npm, you will ne
 const server = require('vue-cli-plugin-apollo/graphql-server')
 
 const opts = {
+  host: 'localhost',
   port: 4000,
   graphqlPath: '/graphql',
   subscriptionsPath: '/graphql',

--- a/graphql-server/index.js
+++ b/graphql-server/index.js
@@ -148,6 +148,7 @@ module.exports = (options, cb = null) => {
   server.installSubscriptionHandlers(httpServer)
 
   httpServer.listen({
+    host: options.host || 'localhost',
     port: options.port,
   }, () => {
     if (!options.quiet) {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const COMMAND_OPTIONS = {
   '--mock': 'enables mocks',
   '--enable-engine': 'enables Apollo Engine',
   '--delay': 'delays run by a small duration',
+  '--host': 'specify server host',
   '--port': 'specify server port',
 }
 
@@ -144,6 +145,8 @@ module.exports = (api, options) => {
       server = server.default || server
 
       // Env
+      const host = args.host || process.env.VUE_APP_GRAPHQL_HOST || 'localhost'
+      process.env.VUE_APP_GRAPHQL_HOST = host
       const port = args.port || process.env.VUE_APP_GRAPHQL_PORT || 4000
       process.env.VUE_APP_GRAPHQL_PORT = port
       const graphqlPath = process.env.VUE_APP_GRAPHQL_PATH || '/graphql'
@@ -155,6 +158,7 @@ module.exports = (api, options) => {
       const baseFolder = defaultValue(apolloOptions.serverFolder, DEFAULT_SERVER_FOLDER)
 
       const opts = {
+        host,
         port,
         graphqlPath,
         subscriptionsPath,


### PR DESCRIPTION
Currently, the value of host can not be changed from `localhost`. This makes it impossible to connect to WebSocket from another device in the same LAN.

In this Pull Request, we make it possible to change the value of host as optional
