### PR TITLE
Update vue-apollo.js template to clarify the link option

### DIFF
--- a/generator/templates/vue-apollo/default/src/vue-apollo.js
+++ b/generator/templates/vue-apollo/default/src/vue-apollo.js
@@ -33,7 +33,9 @@ const defaultOptions = {
   // Is being rendered on the server?
   ssr: false,
 
-  // Override default http link
+  // Override default apollo link
+  // note: don't override httpLink here, specify httpLink options in the
+  // httpLinkOptions property of defaultOptions.
   // link: myLink
 
   // Override default cache


### PR DESCRIPTION
The link option in vue-apollo.js option is misleading, and suggests that you can pass in an httpLink object to override it. Behind the scenes, though, the links are concatted, which results in the console warning about concating terminating links. Other links compositions can be provided to the link option, but passing httpLink won't work and should be handled in `httpLinkOptions` instead. Wording is up to you, but this made me stumble more than it should have.