### PR TITLE
fix typo in api.exitLog

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -177,7 +177,7 @@ module.exports = (api, options, rootOptions) => {
         api.exitLog(`Customize the mocks in ${chalk.cyan('apollo-server/mocks.js')}`, 'info')
       }
       if (options.addApolloEngine) {
-        api.exitLog(`The Apollo Engine API key has been added to ${chalk.cyan('.local.env')}`, 'info')
+        api.exitLog(`The Apollo Engine API key has been added to ${chalk.cyan('.env.local')}`, 'info')
       }
     }
   })


### PR DESCRIPTION
I noticed that the CLI logs that `The Apollo Engine API key..` is created in `.local.env`, but it seems the actual behavior is that the file created is `.env.local`, instead.