### PR TITLE
Enhancement: dataSources

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ const opts = {
     pubsub: require.resolve('some-folder/apollo-server/pubsub.js'),
     server: require.resolve('some-folder/apollo-server/server.js'),
     directives: require.resolve('some-folder/apollo-server/directives.js')
+    dataSources: require.resolve('some-folder/apollo-server/data-sources.js')
   }
 }
 

--- a/generator/templates/api-server/default/apollo-server/data-sources.js
+++ b/generator/templates/api-server/default/apollo-server/data-sources.js
@@ -1,0 +1,3 @@
+export default function() {
+  return {};
+}

--- a/graphql-server/index.js
+++ b/graphql-server/index.js
@@ -26,6 +26,7 @@ module.exports = (options, cb = null) => {
   const resolvers = load(options.paths.resolvers)
   const context = load(options.paths.context)
   const schemaDirectives = load(options.paths.directives)
+  const dataSources = load(options.paths.dataSources)
   let pubsub
   try {
     pubsub = load(options.paths.pubsub)
@@ -57,6 +58,7 @@ module.exports = (options, cb = null) => {
     typeDefs,
     resolvers,
     schemaDirectives,
+    dataSources,
     tracing: true,
     cacheControl: true,
     engine: !options.integratedEngine,

--- a/index.js
+++ b/index.js
@@ -192,6 +192,7 @@ module.exports = (api, options) => {
           apollo: api.resolve(`${baseFolder}/apollo`),
           engine: api.resolve(`${baseFolder}/engine`),
           directives: api.resolve(`${baseFolder}/directives`),
+          dataSources: api.resolve(`${baseFolder}/data-sources`),
         },
       }
 


### PR DESCRIPTION
Related to #67 

Now supports the datasources option for Apollo Server, via the `apollo-server/data-sources.js` file. 

# Caveat

Existing setups will probably break since the data-sources.js file is not present. May want to make this a minor update, or provide a fallback option to the `load` method that returns the fallback if the file is not present.