### PR TITLE
Add `mockEntireSchema: false` to Apollo Server options to preserve existing resolvers

### DIFF
--- a/generator/templates/api-server/default/apollo-server/mocks.js
+++ b/generator/templates/api-server/default/apollo-server/mocks.js
@@ -1,4 +1,4 @@
-// Enable mocking in vue.config.js with `"pluginOptions": { "graphqlMock": true }`
+// Enable mocking in vue.config.js with `"pluginOptions": { "enableMocks": true }`
 // Customize mocking: https://www.apollographql.com/docs/graphql-tools/mocking.html#Customizing-mocks
 export default {
   // Mock resolvers here

--- a/graphql-server/index.js
+++ b/graphql-server/index.js
@@ -102,10 +102,11 @@ module.exports = (options, cb = null) => {
   if (options.enableMocks) {
     // Customize this file
     apolloServerOptions.mocks = load(options.paths.mocks)
+    apolloServerOptions.mockEntireSchema = false
 
     if (!options.quiet) {
       if (process.env.NODE_ENV === 'production') {
-        console.warn(`Automatic mocking is enabled, consider disabling it with the 'graphqlMock' option.`)
+        console.warn(`Automatic mocking is enabled, consider disabling it with the 'enableMocks' option.`)
       } else {
         console.log(`✔️  Automatic mocking is enabled`)
       }


### PR DESCRIPTION
Fix for #69 
With current implementation, if mocks are enabled, any existing resolvers will be overwritten. Adding a `mockEntireSchema` property to Apollo Server options allows to mock only missing resolvers.

Also fixed a name for plugin options: `graphqlMock` => `enableMocks`