### PR TITLE
fix/gql-version-pkg-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "esm": "^3.2.18",
     "execa": "^1.0.0",
     "express": "^4.16.4",
-    "graphql": "^14.1.1",
+    "graphql": "^14.2.1",
     "graphql-subscriptions": "^1.0.0",
     "nodemon": "^1.18.10",
     "subscriptions-transport-ws": "^0.9.16",


### PR DESCRIPTION
Bump `"graphql": "^14.1.1"` to `"graphql": "^14.2.1"` to (among other things) prevent the following warning:
```
warning "vue-cli-plugin-apollo > apollo-server-express > apollo-server-core > apollo-tracing@0.5.2" has incorrect peer dependency "graphql@0.10.x - 14.1.x".
```