### PR TITLE
docs: fix example code for local state

### DIFF
--- a/docs/guide/client-state.md
+++ b/docs/guide/client-state.md
@@ -25,11 +25,11 @@ const options = {
     },
   },
   onCacheInit: cache => {
-    cache.writeData({
+    const data = {
       connected: false,
-    })
+    }
+    cache.writeData({ data })
   },
-},
 }
 
 const { apolloClient } = createApolloClient(options)


### PR DESCRIPTION
Correction of the example code in the docs. The example code generates the error `Uncaught TypeError: Cannot read property 'selections' of null`.