### PR TITLE
fix: use empty object as default inMemoryCacheOptions

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -27,7 +27,7 @@ createApolloClient({
   // Custom Apollo cache implementation (default is apollo-cache-inmemory)
   cache = null,
   // Options for the default cache
-  inMemoryCacheOptions = null,
+  inMemoryCacheOptions = {},
   // Additional Apollo client options
   apollo = {},
   // apollo-link-state options

--- a/graphql-client/src/index.js
+++ b/graphql-client/src/index.js
@@ -35,7 +35,7 @@ export function createApolloClient ({
   // Custom Apollo cache implementation (default is apollo-cache-inmemory)
   cache = null,
   // Options for the default cache
-  inMemoryCacheOptions = null,
+  inMemoryCacheOptions = {},
   // Additional Apollo client options
   apollo = {},
   // apollo-link-state options


### PR DESCRIPTION
Using `null` as default is dangerous here:

1. It passes type checking if `strictNullChecks` not enabled
2. It won't trigger default parameter assignment (only `undefined` will)

In the case of apollo-cache-inmemory v1.6.0, a bug is triggered due to
the default `null` value, see:
https://github.com/apollographql/apollo-client/blob/d9e93e31fa40da6d9ee55e99e8e1cb114dba6639/packages/apollo-cache-inmemory/src/inMemoryCache.ts#L136

Though it can also be fixed on their side, it's better to use a safer
default value.