### PR TITLE
Allow gql-loader to load .gql files from other modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,6 @@ module.exports = (api, options) => {
     const rule = config.module
       .rule('gql')
       .test(/\.(gql|graphql)$/)
-      .include
-      .add(api.resolve('src'))
-      .add(api.resolve('tests'))
-      .end()
       .use('cache-loader')
       .loader('cache-loader')
       .options({ cacheDirectory })


### PR DESCRIPTION
This is useful when importing .gql files from other symlinked packages,
for code sharing purposes.
For example with tools like Lerna and/or yarn workspaces.

PS: None of the loaders which vue-cli configures applies this constrain. Is there any reason why you are using the `include` rule?