### PR TITLE
chore: allow `@vue/cli-shared-utils@4` as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "vuepress": "^0.14.8"
   },
   "peerDependencies": {
-    "@vue/cli-shared-utils": "^3.0.0"
+    "@vue/cli-shared-utils": "^3.0.0 || ^4.0.0-0"
   }
 }


### PR DESCRIPTION
None of the APIs used in this plugin changed in @vue/cli-shared-utils v4