### PR TITLE
Capitalize "Authorization" header name

### DIFF
--- a/graphql-client/src/index.js
+++ b/graphql-client/src/index.js
@@ -73,8 +73,8 @@ export function createApolloClient ({
 
     // HTTP Auth header injection
     authLink = setContext((_, { headers }) => {
-      const authorization = getAuth(tokenName)
-      const authorizationHeader = authorization ? { authorization } : {}
+      const Authorization = getAuth(tokenName)
+      const authorizationHeader = Authorization ? { Authorization } : {}
       return {
         headers: {
           ...headers,
@@ -115,8 +115,8 @@ export function createApolloClient ({
       wsClient = new SubscriptionClient(wsEndpoint, {
         reconnect: true,
         connectionParams: () => {
-          const authorization = getAuth(tokenName)
-          return authorization ? { authorization, headers: { authorization } } : {}
+          const Authorization = getAuth(tokenName)
+          return Authorization ? { Authorization, headers: { Authorization } } : {}
         },
       })
 


### PR DESCRIPTION
HTTP headers are case insensitive, however "Authorization" is a standard header name.

Relevant documentation:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
- https://tools.ietf.org/html/rfc7235#section-4.2

Before:
![image](https://user-images.githubusercontent.com/208149/68038396-283a1800-fcca-11e9-82c1-521878cf0207.png)


After:
![image](https://user-images.githubusercontent.com/208149/68038373-135d8480-fcca-11e9-8ffc-f1aa83a1bb0a.png)
