### PR TITLE
Fix apollo local state link

### DIFF
--- a/docs/guide/client-state.md
+++ b/docs/guide/client-state.md
@@ -1,6 +1,6 @@
 # Client state
 
-You can use [local state](https://www.apollographql.com/docs/react/essentials/local-state.html) for client-only local data with the related options of `createApolloClient`:
+You can use [local state](https://www.apollographql.com/docs/tutorial/local-state/) for client-only local data with the related options of `createApolloClient`:
 
 ```js
 import gql from 'graphql-tag'


### PR DESCRIPTION
I noticed this broken link recently so here's the fix.

I wasn't sure which link to use: the [Apollo Basics - Manage local state](https://www.apollographql.com/docs/tutorial/local-state/) or the [Client (React) - Local state management](https://www.apollographql.com/docs/react/data/local-state/). I used the basic (not react) version, which to me makes more sense. Please let me know if the react one is preferable 🙂 