### PR TITLE
feat: allow getAuth to return a promise

### DIFF
--- a/graphql-client/src/index.js
+++ b/graphql-client/src/index.js
@@ -72,8 +72,8 @@ export function createApolloClient ({
     }
 
     // HTTP Auth header injection
-    authLink = setContext((_, { headers }) => {
-      const authorization = getAuth(tokenName)
+    authLink = setContext(async (_, { headers }) => {
+      const authorization = await getAuth(tokenName)
       const authorizationHeader = authorization ? { authorization } : {}
       return {
         headers: {


### PR DESCRIPTION
https://www.apollographql.com/docs/link/links/context/

Currently it is not possible to retrieve the auth token asynchronously.
This change is very important for my current project. I am currently integrating Auth0 and the new SPA SDK retrieves the auth token asynchronously. It would be amazing, if this could be added soon. Thank you @Akryum 