### PR TITLE
fix: never silence errors

### DIFF
--- a/graphql-server/index.js
+++ b/graphql-server/index.js
@@ -38,7 +38,9 @@ module.exports = (options, cb = null) => {
   let dataSources
   try {
     dataSources = load(options.paths.dataSources)
-  } catch (e) {}
+  } catch (e) {
+    console.error(e)
+  }
 
   // GraphQL API Server
 
@@ -50,6 +52,7 @@ module.exports = (options, cb = null) => {
     const serverModule = load(options.paths.server)
     serverModule(app)
   } catch (e) {
+    console.error(e)
     // No file found
   }
 


### PR DESCRIPTION
I just lost 3 hours of my life not understanding why the `dataSources` field of the third argument of my resolvers were `undefined`.
Just a missing parenthesis, hard to see without a log of the error.

Please never silence errors again, thank you :)