### PR TITLE
fix(generate-schema): load typescript files properly

### DIFF
--- a/graphql-server/index.js
+++ b/graphql-server/index.js
@@ -11,6 +11,8 @@ const { defaultValue, autoCall } = require('../utils')
 require = require('esm')(module)
 
 module.exports = (options, cb = null) => {
+  const { load } = require('../utils/load')(options)
+
   // Default options
   options = merge({
     integratedEngine: false,
@@ -18,8 +20,6 @@ module.exports = (options, cb = null) => {
 
   // Express app
   const app = express()
-
-  if (options.typescript) require('ts-node/register/transpile-only')
 
   // Customize those files
   let typeDefs = load(options.paths.typeDefs)
@@ -169,14 +169,6 @@ module.exports = (options, cb = null) => {
 
     cb && cb()
   })
-}
-
-function load (file) {
-  const module = require(file)
-  if (module.default) {
-    return module.default
-  }
-  return module
 }
 
 function processSchema (typeDefs) {

--- a/utils/generate-schema.js
+++ b/utils/generate-schema.js
@@ -4,9 +4,7 @@ module.exports = async (options) => {
   const { logWithSpinner, stopSpinner, done } = require('@vue/cli-shared-utils')
   const { graphql, introspectionQuery, printSchema } = require('graphql')
   const { makeExecutableSchema } = require('graphql-tools')
-  const { load } = require('./load')
-
-  if (options.typescript) require('ts-node/register/transpile-only')
+  const { load } = require('./load')(options)
 
   // JS Schema
   const typeDefs = load(options.paths.typeDefs)

--- a/utils/load.js
+++ b/utils/load.js
@@ -1,7 +1,15 @@
 // eslint-disable-next-line no-global-assign
 require = require('esm')(module)
 
-exports.load = function (file) {
+module.exports = function (options) {
+  if (options.typescript) require('ts-node/register/transpile-only')
+
+  return {
+    load: load,
+  }
+}
+
+function load (file) {
   const module = require(file)
   if (module.default) {
     return module.default


### PR DESCRIPTION
start using same load module everywhere

When starting new vue-apollo typescript project I've found out that `vue-cli-service apollo:schema:generate` command fails with error `ERROR  Error: Cannot find module '/Users/jakubfreisler/Projects/Web/scrabbio/apollo-server/type-defs'` when type-defs file got `ts` extension (with js file everything've worked as expected).
Also, at the same time, `vue-cli-service apollo:dev` was working (which I was weird for me).

So, after some investigation I found out that:
- `index.js` and `utils/generate-schema.js` modules are using copy-pasted implementation of `load` function, but placed in two different places in the codebase (one was directly in `index.js` file, second one in `utils/load.js`),
- implementation of `load` function which was available within `utils/load.js` module was **not** working with typescript files (raised the error above).

First of all I've pointed both `index.js` and `utils/generate-schema.js` to use the same `load` function from `utils/load.js`.

Then, I've figured out that this function was never working with typescript files properly because `ts-node/register/transpile-only` module was never required in the context of the file `utils/load.js`. The same load implementation contained in `index.js` have worked before, because `ts-node/register/transpile-only` module was required in the `index.js` **before** load function was used (and load function was in the same file = in the same context). And in case of `utils/load` the `ts-node/register/transpile-only` was always required in the file which required also `utils/load.js` (but never in `utils/load.js` itself).

Fix was quite easy - I've just moved `require('ts-node/register/transpile-only')` to the `utils/load.js`. This change fixed the problem and de-duplicated codebase a bit.

@Akryum do you want me to do any additional work before this PR could be merged? 