### PR TITLE
Allow getAuth to return a promise in WS connection

### DIFF
--- a/graphql-client/src/index.js
+++ b/graphql-client/src/index.js
@@ -121,8 +121,8 @@ export function createApolloClient ({
     if (wsEndpoint) {
       wsClient = new SubscriptionClient(wsEndpoint, {
         reconnect: true,
-        connectionParams: () => {
-          const Authorization = getAuth(tokenName)
+        connectionParams: async () => {
+          const Authorization = await getAuth(tokenName)
           return Authorization ? { Authorization, headers: { Authorization } } : {}
         },
       })


### PR DESCRIPTION
Similar to #296

It's supported by `subscriptions-transport-ws` since [v0.9.13](https://github.com/apollographql/subscriptions-transport-ws/blob/master/CHANGELOG.md#v0913).