### PR TITLE
feat: add subscriptions-transport-ws wsProtocols option on client config

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,6 +44,10 @@ createApolloClient({
   clientState: null,
   // Function returning Authorization header token
   getAuth: defaultGetAuth,
+  // subscriptions-transport-ws custom wsProtocols header
+  // it can be undefined, string or string[]
+  // AWS API Gateways does not supports this header, so you can pass []
+  wsProtocols: undefined,
 })
 ```
 

--- a/graphql-client/src/index.js
+++ b/graphql-client/src/index.js
@@ -18,6 +18,8 @@ export function createApolloClient ({
   httpEndpoint,
   // Url to the Websocket API
   wsEndpoint = null,
+  // subscriptions-transport-ws custom wsProtocols
+  wsProtocols = undefined,
   // Token used in localstorage
   tokenName = 'apollo-token',
   // Enable this if you use Query persisting with Apollo Engine
@@ -125,7 +127,7 @@ export function createApolloClient ({
           const Authorization = getAuth(tokenName)
           return Authorization ? { Authorization, headers: { Authorization } } : {}
         },
-      })
+      }, undefined, wsProtocols)
 
       // Create the subscription websocket link
       const wsLink = new WebSocketLink(wsClient)


### PR DESCRIPTION
AWS API Gateway does not support the WebSocket protocol header https://forums.aws.amazon.com/thread.jspa?messageID=883536&tstart=0

original issue: https://github.com/apollographql/subscriptions-transport-ws/issues/520