### PR TITLE
fix: remove implicit requirement of vue-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,6 @@ module.exports = (api, options) => {
     config.module
       .rule('vue')
       .use('vue-loader')
-      .loader('vue-loader')
       .tap(options => {
         options.transpileOptions = options.transpileOptions || {}
         options.transpileOptions.transforms = options.transpileOptions.transforms || {}


### PR DESCRIPTION
`.loader` is a setter rather than a selector.
`.use` alone is sufficient for selecting the loader rule
<https://github.com/neutrinojs/webpack-chain#config-module-rules-uses-loaders-modifying-options>

So this expression implicitly introduced a dependency on the
`vue-loader` name, and expected it to be vue-loader v15, which, isn't
guranteed to be exact the case.

Because Vue CLI supports both Vue 2 and Vue 3 in the core service,
the `vue-loader` dependency used to be v15 and v16 is aliases as
`vue-loader-v16`.

But when I tried to upgrade to webpack 5 and make v16 the default
`vue-loader` dependency, it breaks this plugin and I had to
workaround it.

See <[`7c672bd` (#6060)](https://github.com/vuejs/vue-cli/pull/6060/commits/7c672bd0d7a816aaea55fffcc8b5fbb5e8cfd5da#diff-e201f09cd938f870f5a24c75f97cf10a2a16819caf5f5b154bcc23c4ff915239R99-R106)>