### PR TITLE
fix: eslint path error in workspace

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -82,7 +82,7 @@ module.exports = (api, options, rootOptions) => {
           'graphql/template-strings': ['error', {
             env: 'literal',
             projectName: 'app',
-            schemaJsonFilepath: 'node_modules/.temp/graphql/schema.json',
+            schemaJsonFilepath: `${__dirname}/node_modules/.temp/graphql/schema.json`,
           }],
         },
       },

--- a/generator/templates/vue-apollo/default/src/vue-apollo.js
+++ b/generator/templates/vue-apollo/default/src/vue-apollo.js
@@ -7,6 +7,7 @@ Vue.use(VueApollo)
 
 // Name of the localStorage item
 const AUTH_TOKEN = 'apollo-token'
+const GRAPHQL_WS = process.env.VUE_APP_GRAPHQL_WS
 
 // Http endpoint
 const httpEndpoint = process.env.VUE_APP_GRAPHQL_HTTP || 'http://localhost:4000/graphql'
@@ -22,7 +23,7 @@ const defaultOptions = {
   httpEndpoint,
   // You can use `wss` for secure connection (recommended in production)
   // Use `null` to disable subscriptions
-  wsEndpoint: process.env.VUE_APP_GRAPHQL_WS || 'ws://localhost:4000/graphql',
+  wsEndpoint: GRAPHQL_WS === 'null' ? null : GRAPHQL_WS || 'ws://localhost:4000/graphql',
   // LocalStorage token
   tokenName: AUTH_TOKEN,
   // Enable Automatic Query persisting with Apollo Engine


### PR DESCRIPTION
If the parent project uses the workspace, eslint can't get the related files normally by default and needs to be modified as follows.