### PR TITLE
Update types.d.ts

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -9,7 +9,7 @@ declare module 'vue-cli-plugin-apollo/graphql-client' {
     // URL to the HTTP API
     httpEndpoint?: string
     // Url to the Websocket API
-    wsEndpoint?: string
+    wsEndpoint?: string | null
     // Token used in localstorage
     tokenName?: string
     // Enable this if you use Query persisting with Apollo Engine


### PR DESCRIPTION
Allow wsEndpoint to be a string or null for typescript projects.
Else typescript will throw an error: "Type 'null' is not assignable to type 'string | undefined"