### PR TITLE
Drop support for cache-loader on webpack 5+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 const chalk = require('chalk')
+const semver = require('semver')
+const webpack = require('webpack')
 
 const COMMAND_OPTIONS = {
   '-h, --host': 'specify server host',
@@ -29,13 +31,18 @@ module.exports = (api, options) => {
   const { generateCacheIdentifier } = require('./utils')
 
   api.chainWebpack(config => {
-    const rule = config.module
+    let rule = config.module
       .rule('gql')
       .test(/\.(gql|graphql)$/)
-      .use('cache-loader')
-      .loader('cache-loader')
-      .options({ cacheDirectory })
-      .end()
+    
+    if (semver.major(webpack.version) !== 4) {
+      rule = rule
+        .use('cache-loader')
+        .loader('cache-loader')
+        .options({ cacheDirectory })
+    }
+
+    rule = rule.end()
 
     if (useThreads) {
       rule

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "graphql-tools": "^6.0.9",
     "node-fetch": "^2.6.0",
     "nodemon": "^2.0.4",
+    "semver": "^7.3.5",
     "subscriptions-transport-ws": "^0.9.16",
     "ts-node": "^8.10.2"
   },


### PR DESCRIPTION
Since the release of webpack 5, cache-loader has been deprecated. It currently continues to work with webpack 5, but it has a peerDependency on webpack 4. This causes installs to fail on newer versions of npm 7.


I have a [PR](https://github.com/vuejs/vue-cli/pull/6634) open on vue-cli (which intends to support webpack 5) that drops usage of cache-loader in favor of the new filesystem cache introduced with webpack 5.


The vue-ui package (one of the packages in @vue/cli) depends on this plugin.